### PR TITLE
chore: scaffold CLAUDE.md to ADR 0219 lean template (missing-file catch-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md - metabolic-protocols Project
+
+You are a team member on the metabolic-protocols project, not a tool.
+
+## Project Identifiers
+
+- **Repository:** `martymcenroe/metabolic-protocols`
+- **Project Root (Windows):** `C:\Users\mcwiz\Projects\metabolic-protocols`
+- **Project Root (Unix):** `/c/Users/mcwiz/Projects/metabolic-protocols`
+- **Worktree Pattern:** `metabolic-protocols-{IssueID}`
+
+## Project-Specific Context
+
+**Stack:** Python (Poetry); pytest suite at `tests/`. Layout details in the TODO block below.
+
+_TODO: Add source layout (single-package under `src/{name}/`, script collection in `tools/`, or another shape), architecture notes, key modules, project-specific gotchas, and any workflow overrides. The universal CLAUDE.md (auto-loaded) covers fleet-wide rules -- only add what's true for THIS repo specifically (ADR 0219)._
+
+## Workflow Overrides
+
+_None yet. If this project needs to override any universal CLAUDE.md rule (e.g., a custom merge tool, a special test convention), document the override here with explicit language ("override") per ADR 0219._


### PR DESCRIPTION
## Summary

Creates a CLAUDE.md from the lean per-repo template per AssemblyZero ADR 0219. Resolves lint MISSING status.

Project-type signal detected from local file presence (pyproject.toml/package.json/etc.). Uses the matching new_repo_setup.py stub.

No-Issue: scaffolder catch-up -- creates missing CLAUDE.md per AssemblyZero ADR 0219 lean template, applying #1290 lint sweep. Operator-authorized fleet sweep 2026-05-26.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)