### PR TITLE
fix(pyproject): valid PEP 440 requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Marty McEnroe",email = "martymcenroe@users.noreply.github.com"}
 ]
 readme = "README.md"
-requires-python = "^3.11"
+requires-python = ">=3.11,<4.0"
 dependencies = [
 ]
 


### PR DESCRIPTION
Normalize `requires-python` `^3.11` -> `>=3.11,<4.0` to valid PEP 440 so ruff and other PEP 621 consumers can parse pyproject.toml. poetry.lock regenerated for the new hash.

No-Issue: requires-python PEP 440 normalization, fleet backfill (AssemblyZero #1574)